### PR TITLE
Modularize server with separated services for tests

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,80 +1,9 @@
 const express = require('express');
-const { OpenAI } = require('openai');
-const { chromium } = require('playwright');
-const { v4: uuidv4 } = require('uuid');
+const tests = require('./routes/tests');
 
 const app = express();
 app.use(express.json({ limit: '1mb' }));
-
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-const tests = new Map();
-
-app.post('/tests', async (req, res) => {
-  const { description, url } = req.body || {};
-  if (!description || !url) {
-    return res.status(400).json({ error: 'description and url required' });
-  }
-
-  const id = uuidv4();
-  tests.set(id, { status: 'running' });
-
-  (async () => {
-    try {
-      const codePrompt = `Generate a JavaScript async function using Playwright's page object to test: ${description}. Navigate to ${url}. Return as plain code without backticks.`;
-      const gen = await openai.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [
-          { role: 'system', content: 'You generate Playwright test functions.' },
-          { role: 'user', content: codePrompt }
-        ]
-      });
-      const code = gen.choices[0].message.content.trim();
-
-      const browser = await chromium.launch();
-      const page = await browser.newPage();
-
-      const testFunc = eval(`(async ({page}) => {${code}})`);
-      await testFunc({ page });
-
-      const dom = await page.content();
-      const screenshot = await page.screenshot({ encoding: 'base64' });
-      await browser.close();
-
-      const validation = await openai.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [
-          {
-            role: 'user',
-            content: [
-              { type: 'text', text: `Validate the following DOM against this description: ${description}` },
-              { type: 'text', text: dom },
-              {
-                type: 'image_url',
-                image_url: { url: `data:image/png;base64,${screenshot}` }
-              }
-            ]
-          }
-        ]
-      });
-
-      tests.set(id, {
-        status: 'completed',
-        result: validation.choices[0].message.content,
-        screenshot: `data:image/png;base64,${screenshot}`
-      });
-    } catch (err) {
-      tests.set(id, { status: 'error', error: err.message });
-    }
-  })();
-
-  res.json({ id });
-});
-
-app.get('/tests/:id/results', (req, res) => {
-  const data = tests.get(req.params.id);
-  if (!data) return res.status(404).json({ error: 'not found' });
-  res.json(data);
-});
+app.use('/tests', tests);
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/server/routes/tests.js
+++ b/server/routes/tests.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const { v4: uuidv4 } = require('uuid');
+const { generateTestCode, validateDom } = require('../services/openai');
+const { runTest } = require('../services/playwright');
+
+const router = express.Router();
+const tests = new Map();
+
+router.post('/', async (req, res) => {
+  const { description, url } = req.body || {};
+  if (!description || !url) {
+    return res.status(400).json({ error: 'description and url required' });
+  }
+
+  const id = uuidv4();
+  tests.set(id, { status: 'running' });
+
+  (async () => {
+    try {
+      const code = await generateTestCode(description, url);
+      const { dom, screenshot } = await runTest(code);
+      const result = await validateDom(description, dom, screenshot);
+      tests.set(id, {
+        status: 'completed',
+        result,
+        screenshot: `data:image/png;base64,${screenshot}`
+      });
+    } catch (err) {
+      tests.set(id, { status: 'error', error: err.message });
+    }
+  })();
+
+  res.json({ id });
+});
+
+router.get('/:id/results', (req, res) => {
+  const data = tests.get(req.params.id);
+  if (!data) return res.status(404).json({ error: 'not found' });
+  res.json(data);
+});
+
+module.exports = router;

--- a/server/services/openai.js
+++ b/server/services/openai.js
@@ -1,0 +1,37 @@
+const { OpenAI } = require('openai');
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function generateTestCode(description, url) {
+  const codePrompt = `Generate a JavaScript async function using Playwright's page object to test: ${description}. Navigate to ${url}. Return as plain code without backticks.`;
+  const gen = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      { role: 'system', content: 'You generate Playwright test functions.' },
+      { role: 'user', content: codePrompt }
+    ]
+  });
+  return gen.choices[0].message.content.trim();
+}
+
+async function validateDom(description, dom, screenshot) {
+  const validation = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: `Validate the following DOM against this description: ${description}` },
+          { type: 'text', text: dom },
+          {
+            type: 'image_url',
+            image_url: { url: `data:image/png;base64,${screenshot}` }
+          }
+        ]
+      }
+    ]
+  });
+  return validation.choices[0].message.content;
+}
+
+module.exports = { generateTestCode, validateDom };

--- a/server/services/playwright.js
+++ b/server/services/playwright.js
@@ -1,0 +1,14 @@
+const { chromium } = require('playwright');
+
+async function runTest(code) {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const testFunc = eval(`(async ({page}) => {${code}})`);
+  await testFunc({ page });
+  const dom = await page.content();
+  const screenshot = await page.screenshot({ encoding: 'base64' });
+  await browser.close();
+  return { dom, screenshot };
+}
+
+module.exports = { runTest };


### PR DESCRIPTION
## Summary
- Refactor server entry to mount tests router
- Add tests router that orchestrates OpenAI generation, Playwright execution, and validation with job tracking
- Create OpenAI and Playwright service modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a01d7613c4833299f946d13d34094a